### PR TITLE
Fix django migration node not found errors

### DIFF
--- a/MIGRATION_FIX_GUIDE.md
+++ b/MIGRATION_FIX_GUIDE.md
@@ -1,0 +1,116 @@
+# Django Migration Fix Guide
+
+## Problem Description
+
+You're encountering a `NodeNotFoundError` for the CommonItems app:
+```
+django.db.migrations.exceptions.NodeNotFoundError: Migration CommonItems.0004_alter_vehiclesize_options_alter_vehicletype_options_and_more dependencies reference nonexistent parent node ('CommonItems', '0003_alter_commonitem_options_alter_itembrand_options_and_more')
+```
+
+## Root Cause
+
+This error typically occurs when:
+1. The migration files exist on disk but Django's migration history in the database is out of sync
+2. Migrations were applied and then the files were modified or renamed
+3. The database was copied from another environment with different migration history
+
+## Solution Steps
+
+### Step 1: Verify Migration Files Exist
+
+First, confirm that all migration files are present:
+```bash
+ls -la apps/CommonItems/migrations/
+```
+
+You should see:
+- `0001_initial.py`
+- `0002_initial.py`
+- `0003_alter_commonitem_options_alter_itembrand_options_and_more.py`
+- `0004_alter_vehiclesize_options_alter_vehicletype_options_and_more.py`
+
+✅ **Status**: All files are present and have correct syntax.
+
+### Step 2: Fix the Migration Issue
+
+Run these commands in your virtual environment:
+
+```bash
+# Activate your virtual environment first
+source /home/ellis_1/MoreVans-BE/venv/bin/activate
+
+# Option 1: Fake the migrations (recommended)
+python manage.py migrate CommonItems 0002_initial --fake
+python manage.py migrate CommonItems 0003_alter_commonitem_options_alter_itembrand_options_and_more --fake
+python manage.py migrate CommonItems 0004_alter_vehiclesize_options_alter_vehicletype_options_and_more --fake
+
+# Then apply all other migrations
+python manage.py migrate
+```
+
+### Step 3: If Step 2 Doesn't Work
+
+Try these alternatives:
+
+#### Option A: Reset and Reapply (if database is empty)
+```bash
+python manage.py migrate CommonItems zero
+python manage.py migrate CommonItems --fake-initial
+python manage.py migrate
+```
+
+#### Option B: Database Surgery (advanced)
+1. Access your database and run:
+```sql
+-- Check current migration state
+SELECT * FROM django_migrations WHERE app = 'CommonItems';
+
+-- Remove problematic entries
+DELETE FROM django_migrations WHERE app = 'CommonItems' AND name = '0003_alter_commonitem_options_alter_itembrand_options_and_more';
+DELETE FROM django_migrations WHERE app = 'CommonItems' AND name = '0004_alter_vehiclesize_options_alter_vehicletype_options_and_more';
+```
+
+2. Then fake the migrations:
+```bash
+python manage.py migrate CommonItems --fake
+```
+
+### Step 4: Verify All Apps
+
+After fixing CommonItems, check all other apps:
+```bash
+python manage.py showmigrations
+```
+
+If you see any unapplied migrations (marked with `[ ]`), run:
+```bash
+python manage.py migrate
+```
+
+## Files Created to Help
+
+1. **`analyze_migrations.py`** - Analyzes migration dependencies without Django
+2. **`reset_migrations.py`** - Generates SQL commands to reset migrations
+3. **`fix_all_migrations.sh`** - Interactive script to fix migrations
+4. **`migration_fix_commands.txt`** - List of commands to run
+
+## Prevention
+
+To avoid this issue in the future:
+1. Always use version control for migration files
+2. Don't modify migration files after they've been applied
+3. Use `--fake` flag carefully and only when you're sure the database schema matches
+4. Keep migration history synchronized across all environments
+
+## Additional Notes
+
+- The analysis shows all migration files are present and have correct dependencies
+- The only non-Django dependency is on `auth.0012_alter_user_first_name_max_length` in the User app, which is normal
+- All migration files compile without syntax errors
+
+If you continue to have issues after following these steps, the problem might be:
+1. Database connection issues
+2. Permissions problems
+3. Corrupted migration history in the database
+
+In such cases, consider starting with a fresh database if possible.

--- a/analyze_migrations.py
+++ b/analyze_migrations.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Script to analyze Django migration files and identify dependency issues.
+"""
+
+import os
+import re
+from pathlib import Path
+
+def extract_migration_info(file_path):
+    """Extract migration class name and dependencies from a migration file."""
+    with open(file_path, 'r') as f:
+        content = f.read()
+    
+    # Extract class name
+    class_match = re.search(r'class\s+(\w+)\s*\(.*Migration.*\):', content)
+    class_name = class_match.group(1) if class_match else None
+    
+    # Extract dependencies
+    deps_match = re.search(r'dependencies\s*=\s*\[(.*?)\]', content, re.DOTALL)
+    dependencies = []
+    
+    if deps_match:
+        deps_str = deps_match.group(1)
+        # Find all tuples in dependencies
+        tuple_pattern = r'\(\s*[\'"](\w+)[\'"]\s*,\s*[\'"]([^\'\"]+)[\'"]\s*\)'
+        for match in re.finditer(tuple_pattern, deps_str):
+            app_name, migration_name = match.groups()
+            dependencies.append((app_name, migration_name))
+    
+    return class_name, dependencies
+
+def analyze_app_migrations(app_path):
+    """Analyze all migrations in an app."""
+    migrations_dir = app_path / 'migrations'
+    if not migrations_dir.exists():
+        return {}
+    
+    migrations = {}
+    for file_path in sorted(migrations_dir.glob('*.py')):
+        if file_path.name != '__init__.py':
+            try:
+                class_name, deps = extract_migration_info(file_path)
+                migrations[file_path.stem] = {
+                    'file': file_path,
+                    'class': class_name,
+                    'dependencies': deps
+                }
+            except Exception as e:
+                print(f"Error reading {file_path}: {e}")
+    
+    return migrations
+
+def check_all_apps():
+    """Check all apps for migration issues."""
+    apps_dir = Path('apps')
+    all_migrations = {}
+    
+    # First pass: collect all migrations
+    for app_dir in sorted(apps_dir.iterdir()):
+        if app_dir.is_dir() and not app_dir.name.startswith('__'):
+            app_name = app_dir.name
+            migrations = analyze_app_migrations(app_dir)
+            if migrations:
+                all_migrations[app_name] = migrations
+    
+    # Second pass: check dependencies
+    issues = []
+    for app_name, migrations in all_migrations.items():
+        for migration_name, migration_info in migrations.items():
+            for dep_app, dep_migration in migration_info['dependencies']:
+                # Check if dependency exists
+                if dep_app not in all_migrations:
+                    issues.append({
+                        'type': 'missing_app',
+                        'app': app_name,
+                        'migration': migration_name,
+                        'missing': f"{dep_app} (entire app)"
+                    })
+                elif dep_migration not in all_migrations[dep_app]:
+                    issues.append({
+                        'type': 'missing_migration',
+                        'app': app_name,
+                        'migration': migration_name,
+                        'missing': f"{dep_app}.{dep_migration}"
+                    })
+    
+    return all_migrations, issues
+
+def print_report(all_migrations, issues):
+    """Print a detailed report of migrations and issues."""
+    print("Django Migration Analysis Report")
+    print("=" * 60)
+    
+    # Print all migrations by app
+    print("\nMigrations by App:")
+    for app_name, migrations in sorted(all_migrations.items()):
+        print(f"\n{app_name}:")
+        for migration_name in sorted(migrations.keys()):
+            deps = migrations[migration_name]['dependencies']
+            print(f"  - {migration_name}")
+            if deps:
+                for dep_app, dep_migration in deps:
+                    print(f"      → depends on: {dep_app}.{dep_migration}")
+    
+    # Print issues
+    print("\n" + "=" * 60)
+    print("Issues Found:")
+    if not issues:
+        print("✓ No migration dependency issues found!")
+    else:
+        for issue in issues:
+            print(f"\n✗ {issue['app']}.{issue['migration']}")
+            print(f"  Missing dependency: {issue['missing']}")
+
+def main():
+    """Main function."""
+    all_migrations, issues = check_all_apps()
+    print_report(all_migrations, issues)
+    
+    if issues:
+        print("\n" + "=" * 60)
+        print("Recommended Actions:")
+        print("1. Check if migration files were renamed or deleted")
+        print("2. Ensure all apps are properly installed in INSTALLED_APPS")
+        print("3. Run 'python manage.py makemigrations' to create missing migrations")
+        print("4. Consider resetting migrations if the database is empty")
+
+if __name__ == "__main__":
+    main()

--- a/fix_all_migrations.sh
+++ b/fix_all_migrations.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# Django Migration Fix Script
+# This script provides various options to fix Django migration issues
+
+echo "Django Migration Fix Script"
+echo "=========================="
+echo ""
+echo "This script will help fix migration issues in your Django project."
+echo "Make sure you have:"
+echo "1. Activated your virtual environment"
+echo "2. Set up your database connection"
+echo "3. Backed up your database (if it contains important data)"
+echo ""
+echo "Press Enter to continue or Ctrl+C to cancel..."
+read
+
+# Function to run Django commands
+run_django_command() {
+    echo "Running: $1"
+    python manage.py $1
+    if [ $? -ne 0 ]; then
+        echo "Command failed. Make sure your virtual environment is activated and Django is installed."
+        exit 1
+    fi
+}
+
+echo ""
+echo "Choose an option:"
+echo "1. Show current migration status"
+echo "2. Fix CommonItems migration issue (fake migrations)"
+echo "3. Reset all migrations (WARNING: Only for empty databases)"
+echo "4. Apply all migrations normally"
+echo "5. Check for migration conflicts"
+echo ""
+read -p "Enter your choice (1-5): " choice
+
+case $choice in
+    1)
+        echo ""
+        echo "Showing migration status..."
+        run_django_command "showmigrations"
+        ;;
+    
+    2)
+        echo ""
+        echo "Fixing CommonItems migration issue..."
+        echo "This will mark the migrations as applied without running them."
+        echo ""
+        
+        # First, try to fake up to migration 0002
+        echo "Step 1: Faking migration up to 0002_initial..."
+        run_django_command "migrate CommonItems 0002_initial --fake"
+        
+        # Then fake the problematic migration
+        echo ""
+        echo "Step 2: Faking the problematic migration 0003..."
+        run_django_command "migrate CommonItems 0003_alter_commonitem_options_alter_itembrand_options_and_more --fake"
+        
+        # Finally, fake the last migration
+        echo ""
+        echo "Step 3: Faking migration 0004..."
+        run_django_command "migrate CommonItems 0004_alter_vehiclesize_options_alter_vehicletype_options_and_more --fake"
+        
+        echo ""
+        echo "CommonItems migrations have been marked as applied."
+        echo "Now applying all other migrations..."
+        run_django_command "migrate"
+        ;;
+    
+    3)
+        echo ""
+        echo "WARNING: This will reset all migrations!"
+        echo "Only use this if your database is empty or you don't care about the data."
+        read -p "Are you sure? (yes/no): " confirm
+        
+        if [ "$confirm" = "yes" ]; then
+            echo ""
+            echo "Resetting all migrations..."
+            
+            # Get all app names
+            apps=$(find apps -maxdepth 1 -type d -name "[!_]*" -exec basename {} \; | sort)
+            
+            for app in $apps; do
+                echo "Resetting $app..."
+                run_django_command "migrate $app zero --fake" 2>/dev/null || true
+            done
+            
+            echo ""
+            echo "All migrations reset. Now applying migrations with --fake-initial..."
+            run_django_command "migrate --fake-initial"
+        else
+            echo "Operation cancelled."
+        fi
+        ;;
+    
+    4)
+        echo ""
+        echo "Applying all migrations normally..."
+        run_django_command "migrate"
+        ;;
+    
+    5)
+        echo ""
+        echo "Checking for migration conflicts..."
+        run_django_command "makemigrations --check --dry-run"
+        ;;
+    
+    *)
+        echo "Invalid choice. Exiting."
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "Done! Check the output above for any errors."
+echo ""
+echo "If you still have issues:"
+echo "1. Check that all apps are in INSTALLED_APPS in settings.py"
+echo "2. Make sure all migration files are present"
+echo "3. Consider deleting migration records from django_migrations table"
+echo "4. As a last resort, delete all migration files (except __init__.py) and recreate them"

--- a/fix_migrations.py
+++ b/fix_migrations.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Script to fix Django migration issues by checking and resolving dependency problems.
+"""
+
+import os
+import sys
+import django
+from pathlib import Path
+
+# Add the project root to the Python path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Set up Django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
+django.setup()
+
+from django.apps import apps
+from django.db import connection
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.exceptions import NodeNotFoundError
+
+def check_migrations():
+    """Check for migration issues and report them."""
+    print("Checking migrations...")
+    
+    try:
+        loader = MigrationLoader(connection)
+        loader.build_graph()
+        print("✓ Migration graph built successfully!")
+        return True
+    except NodeNotFoundError as e:
+        print(f"✗ Migration dependency error: {e}")
+        return False
+    except Exception as e:
+        print(f"✗ Unexpected error: {e}")
+        return False
+
+def list_all_migrations():
+    """List all migrations in the project."""
+    print("\nListing all migrations by app:")
+    
+    for app_config in apps.get_app_configs():
+        if app_config.path.startswith(str(Path(__file__).parent / 'apps')):
+            app_label = app_config.label
+            migrations_dir = Path(app_config.path) / 'migrations'
+            
+            if migrations_dir.exists():
+                migration_files = sorted([
+                    f.stem for f in migrations_dir.glob('*.py')
+                    if f.stem != '__init__'
+                ])
+                
+                if migration_files:
+                    print(f"\n{app_label}:")
+                    for migration in migration_files:
+                        print(f"  - {migration}")
+
+def check_migration_dependencies():
+    """Check each app's migration dependencies."""
+    print("\nChecking migration dependencies:")
+    
+    issues = []
+    
+    for app_config in apps.get_app_configs():
+        if app_config.path.startswith(str(Path(__file__).parent / 'apps')):
+            app_label = app_config.label
+            migrations_dir = Path(app_config.path) / 'migrations'
+            
+            if migrations_dir.exists():
+                for migration_file in sorted(migrations_dir.glob('*.py')):
+                    if migration_file.stem != '__init__':
+                        try:
+                            # Read the migration file
+                            content = migration_file.read_text()
+                            
+                            # Look for dependencies
+                            if 'dependencies = [' in content:
+                                start = content.find('dependencies = [')
+                                end = content.find(']', start) + 1
+                                deps_section = content[start:end]
+                                
+                                # Extract dependencies
+                                import ast
+                                try:
+                                    # Parse the dependencies list
+                                    deps_str = deps_section.split('=', 1)[1].strip()
+                                    dependencies = ast.literal_eval(deps_str)
+                                    
+                                    for dep in dependencies:
+                                        if isinstance(dep, tuple) and len(dep) == 2:
+                                            dep_app, dep_migration = dep
+                                            
+                                            # Check if dependency exists
+                                            dep_app_config = apps.get_app_config(dep_app)
+                                            dep_migrations_dir = Path(dep_app_config.path) / 'migrations'
+                                            dep_file = dep_migrations_dir / f"{dep_migration}.py"
+                                            
+                                            if not dep_file.exists():
+                                                issues.append({
+                                                    'app': app_label,
+                                                    'migration': migration_file.stem,
+                                                    'missing_dep': f"{dep_app}.{dep_migration}"
+                                                })
+                                                print(f"✗ {app_label}.{migration_file.stem} depends on missing {dep_app}.{dep_migration}")
+                                            else:
+                                                print(f"✓ {app_label}.{migration_file.stem} -> {dep_app}.{dep_migration}")
+                                except:
+                                    pass
+                        except Exception as e:
+                            print(f"Error reading {migration_file}: {e}")
+    
+    return issues
+
+def suggest_fixes(issues):
+    """Suggest fixes for migration issues."""
+    if not issues:
+        print("\n✓ No migration dependency issues found!")
+        return
+    
+    print("\nSuggested fixes:")
+    for issue in issues:
+        print(f"\nIssue: {issue['app']}.{issue['migration']} depends on missing {issue['missing_dep']}")
+        print("Possible solutions:")
+        print("1. Check if the dependency migration file exists but has a different name")
+        print("2. Run 'python manage.py makemigrations' to create missing migrations")
+        print("3. Reset migrations for the affected app (use with caution)")
+
+def main():
+    """Main function to run migration checks."""
+    print("Django Migration Fixer")
+    print("=" * 50)
+    
+    # Check if migrations can be loaded
+    can_load = check_migrations()
+    
+    # List all migrations
+    list_all_migrations()
+    
+    # Check dependencies
+    issues = check_migration_dependencies()
+    
+    # Suggest fixes
+    suggest_fixes(issues)
+    
+    if not can_load:
+        print("\n⚠️  Migration loader failed. You may need to:")
+        print("1. Delete migration files and recreate them")
+        print("2. Reset the database migration history")
+        print("3. Fix dependency issues manually")
+    
+    print("\n" + "=" * 50)
+    print("Migration check complete!")
+
+if __name__ == "__main__":
+    main()

--- a/migration_fix_commands.txt
+++ b/migration_fix_commands.txt
@@ -1,0 +1,39 @@
+# Django Migration Fix Commands
+# =============================
+
+# These commands should be run in your Django project with the virtual environment activated
+
+# 1. First, check the current migration status:
+python manage.py showmigrations CommonItems
+
+# 2. If you see that CommonItems.0003 is not recognized, but the file exists, try:
+python manage.py migrate CommonItems 0002_initial --fake
+python manage.py migrate CommonItems 0003_alter_commonitem_options_alter_itembrand_options_and_more --fake
+python manage.py migrate CommonItems 0004_alter_vehiclesize_options_alter_vehicletype_options_and_more --fake
+
+# 3. Then apply all other migrations:
+python manage.py migrate
+
+# Alternative approach if the above doesn't work:
+
+# Option A: Reset CommonItems migrations (if database is empty or you can afford to lose CommonItems data)
+python manage.py migrate CommonItems zero
+python manage.py migrate CommonItems --fake-initial
+
+# Option B: If you're getting the error during initial setup, try:
+python manage.py migrate --fake-initial
+
+# Option C: If nothing else works, you might need to:
+# 1. Delete the problematic migration from django_migrations table:
+#    Run this SQL in your database:
+#    DELETE FROM django_migrations WHERE app = 'CommonItems' AND name LIKE '0003%';
+#    DELETE FROM django_migrations WHERE app = 'CommonItems' AND name LIKE '0004%';
+#
+# 2. Then fake the migrations:
+#    python manage.py migrate CommonItems --fake
+
+# To check for any other migration issues in all apps:
+python manage.py showmigrations
+
+# If you see any apps with unapplied migrations, run:
+python manage.py migrate

--- a/reset_migrations.py
+++ b/reset_migrations.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Script to generate SQL commands to reset Django migration state.
+This is useful when migration files exist but the database thinks they don't.
+"""
+
+import os
+from pathlib import Path
+
+def generate_reset_sql():
+    """Generate SQL commands to reset migration state."""
+    
+    print("-- SQL Commands to Reset Django Migration State")
+    print("-- WARNING: Only run these if you understand the implications!")
+    print("-- This will mark all migrations as not applied.")
+    print("-- Make sure to backup your database first!")
+    print()
+    
+    # Generate SQL to show current migration state
+    print("-- First, check current migration state:")
+    print("SELECT * FROM django_migrations ORDER BY app, name;")
+    print()
+    
+    # Generate SQL to delete specific problematic migrations
+    print("-- If you need to reset specific migrations:")
+    print("-- Delete the problematic CommonItems migrations:")
+    print("DELETE FROM django_migrations WHERE app = 'CommonItems' AND name = '0003_alter_commonitem_options_alter_itembrand_options_and_more';")
+    print("DELETE FROM django_migrations WHERE app = 'CommonItems' AND name = '0004_alter_vehiclesize_options_alter_vehicletype_options_and_more';")
+    print()
+    
+    # Generate SQL to reset all migrations for an app
+    print("-- Or reset all CommonItems migrations:")
+    print("-- DELETE FROM django_migrations WHERE app = 'CommonItems';")
+    print()
+    
+    # List all apps that might need resetting
+    apps_dir = Path('apps')
+    app_names = []
+    
+    for app_dir in sorted(apps_dir.iterdir()):
+        if app_dir.is_dir() and not app_dir.name.startswith('__'):
+            migrations_dir = app_dir / 'migrations'
+            if migrations_dir.exists() and any(migrations_dir.glob('*.py')):
+                app_names.append(app_dir.name)
+    
+    print("-- To reset ALL app migrations (use with extreme caution):")
+    for app_name in app_names:
+        print(f"-- DELETE FROM django_migrations WHERE app = '{app_name}';")
+    
+    print()
+    print("-- After deleting migration records, you can re-apply migrations with:")
+    print("-- python manage.py migrate --fake")
+    print("-- or")
+    print("-- python manage.py migrate --fake-initial")
+
+def generate_migration_commands():
+    """Generate Django management commands to fix migrations."""
+    
+    print("\n" + "="*60)
+    print("Django Management Commands to Fix Migrations")
+    print("="*60)
+    print()
+    
+    print("# Option 1: Fake the specific migration that's causing issues")
+    print("python manage.py migrate CommonItems 0002_initial --fake")
+    print("python manage.py migrate CommonItems 0003_alter_commonitem_options_alter_itembrand_options_and_more --fake")
+    print("python manage.py migrate CommonItems 0004_alter_vehiclesize_options_alter_vehicletype_options_and_more --fake")
+    print()
+    
+    print("# Option 2: Show current migration state")
+    print("python manage.py showmigrations CommonItems")
+    print()
+    
+    print("# Option 3: Reset all migrations for CommonItems (if database is empty)")
+    print("python manage.py migrate CommonItems zero")
+    print("python manage.py migrate CommonItems --fake-initial")
+    print()
+    
+    print("# Option 4: If you need to recreate migrations")
+    print("# First, backup and remove migration files (except __init__.py)")
+    print("# Then:")
+    print("python manage.py makemigrations CommonItems")
+    print("python manage.py migrate CommonItems --fake-initial")
+
+def main():
+    """Main function."""
+    print("Migration Reset Helper")
+    print("=====================")
+    print()
+    print("This script generates commands to help fix Django migration issues.")
+    print()
+    
+    generate_reset_sql()
+    generate_migration_commands()
+    
+    print("\n" + "="*60)
+    print("IMPORTANT NOTES:")
+    print("="*60)
+    print("1. Always backup your database before running these commands")
+    print("2. The --fake flag tells Django to mark migrations as applied without running them")
+    print("3. Only use --fake if the database schema already matches the migration")
+    print("4. If you're starting fresh, you might want to drop and recreate the database")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add tools and documentation to diagnose and fix Django migration `NodeNotFoundError`.

The `NodeNotFoundError` for `CommonItems.0004` referencing `CommonItems.0003` was due to the Django database migration history being out of sync with the actual migration files on disk, despite the files existing and having correct dependencies. This PR provides scripts and a guide to help diagnose and correct this common Django migration state issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc384567-e7c8-4304-a4e4-17113044be9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc384567-e7c8-4304-a4e4-17113044be9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>